### PR TITLE
Coins linked with the shop

### DIFF
--- a/Escaping Amnesia/Assets/Scenes/UpgradeRoom-2.unity
+++ b/Escaping Amnesia/Assets/Scenes/UpgradeRoom-2.unity
@@ -18290,7 +18290,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1511825737}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
@@ -18611,6 +18611,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   contentPanel: {fileID: 1665162070}
   cardShopCanvas: {fileID: 1511825737}
+  playerCoins: 0
 --- !u!4 &1532162585
 Transform:
   m_ObjectHideFlags: 0
@@ -19864,7 +19865,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0.000030517578, y: 0}
-  m_SizeDelta: {x: -401.8426, y: 50}
+  m_SizeDelta: {x: -386.8426, y: 50}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1665162071
 MonoBehaviour:

--- a/Escaping Amnesia/Assets/ShopDisplay.cs
+++ b/Escaping Amnesia/Assets/ShopDisplay.cs
@@ -4,18 +4,17 @@ using UnityEngine;
 using TMPro;
 using UnityEngine.UI;
 using BattleCards;
-using System.Diagnostics;
 
 public class ShopDisplay : MonoBehaviour
 {
     public Transform contentPanel;
     public GameObject cardShopCanvas; // Assign the card shop canvas in the Inspector
     private List<Card> cards;
-    //private List<Card> playerDeck;
+    public GameObject coinCount;
 
     void Start()
     {
-        //playerDeck = new List<Card>();
+        coinCount = GameObject.Find("Player Coins");
         LoadCards();
         DisplayCards();
     }
@@ -28,43 +27,72 @@ public class ShopDisplay : MonoBehaviour
 
     void DisplayCards()
     {
+        int playerCoins = coinCount.GetComponent<playerCoinCounter>().currentCoinCount;
+
         foreach (Card card in cards)
         {
+            // Create a GameObject for each card button
             GameObject textObject = new GameObject(card.cardName);
             textObject.transform.SetParent(contentPanel, false);
 
+            // Set up the TextMeshProUGUI component to display card details and cost
             TextMeshProUGUI cardText = textObject.AddComponent<TextMeshProUGUI>();
-            cardText.text = $"Name: {card.cardName}\nHealth: {card.maxHealth} Damage: {card.damage} Energy: {card.energy}";
+            cardText.text = $"Name: {card.cardName}\nHealth: {card.maxHealth} Damage: {card.damage} Energy: {card.energy}\nCost: {card.energy}";
             cardText.fontSize = 24;
             cardText.alignment = TextAlignmentOptions.Center;
             cardText.enableWordWrapping = true;
 
+            // Set up the Button component
             Button button = textObject.AddComponent<Button>();
             button.transition = Selectable.Transition.ColorTint;
 
+            // Check if the player has enough coins for the card
+            if (playerCoins >= card.energy)
+            {
+                // Player can afford the card, set the color to default
+                cardText.color = Color.black; // or whatever default color you want
+                button.interactable = true;
+            }
+            else
+            {
+                // Player cannot afford the card, set the color to red and disable the button
+                cardText.color = Color.red;
+                button.interactable = false;
+            }
+
+            // Define button color settings
             ColorBlock colorBlock = button.colors;
             colorBlock.normalColor = Color.white;
             colorBlock.highlightedColor = new Color(0.9f, 0.9f, 1, 1);
             colorBlock.pressedColor = new Color(0.7f, 0.7f, 0.7f, 1);
             colorBlock.selectedColor = Color.white;
             colorBlock.disabledColor = new Color(0.5f, 0.5f, 0.5f, 1);
-            colorBlock.colorMultiplier = 1;
             button.colors = colorBlock;
 
+            // Add an onClick listener to check if the player can buy the card
             button.onClick.AddListener(() => OnCardSelected(card));
         }
     }
 
     void OnCardSelected(Card card)
     {
-        //playerDeck.Add(card);
-        UnityEngine.Debug.Log($"Added Card to Deck: {card.cardName}\nHealth: {card.currentHealth}/{card.maxHealth}\nDamage: {card.damage}\nEnergy: {card.energy}");
-        //Debug.Log($"Current Deck Size: {playerDeck.Count}");
-
-        // Hide the card shop canvas after selecting a card
-        if (cardShopCanvas != null)
+        // Check if the player has enough coins to buy the card
+        if (coinCount.GetComponent<playerCoinCounter>().currentCoinCount >= card.energy)
         {
-            cardShopCanvas.SetActive(false);
+            // Deduct card cost from player's coins
+            coinCount.GetComponent<playerCoinCounter>().currentCoinCount -= card.energy;
+
+            // Log the purchase and hide the card shop canvas
+            UnityEngine.Debug.Log($"Added Card to Deck: {card.cardName} for {card.energy} coins");
+
+            if (cardShopCanvas != null)
+            {
+                cardShopCanvas.SetActive(false);
+            }
+        }
+        else
+        {
+            UnityEngine.Debug.Log("Not enough coins to purchase this card.");
         }
     }
 }


### PR DESCRIPTION
Linked the players coin count to the card shop. Restricts the player from buying cards that they cant purchase. 
The text is red for the cards that cant be purchased and removes the ability to click the button.